### PR TITLE
Fix usage for webp in doc

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,8 +90,8 @@ For [browsers that don't yet support WebP][caniuse-webp], you can also provide a
 ```vue
 <template>
   <picture>
-    <source :src="require('~/assets/my-image.jpg?webp')" type="image/webp" />
-    <source :src="require('~/assets/my-image.jpg')" type="image/jpeg" />
+    <source :srcset="require('~/assets/my-image.jpg?webp')" type="image/webp" />
+    <source :srcset="require('~/assets/my-image.jpg')" type="image/jpeg" />
     <img :src="require('~/assets/my-image.jpg')" />
   </picture>
 </template>


### PR DESCRIPTION
Hi, thank you for creating awesome plugin.

I've just used this plugin for making my friend's homepage and noticed a little bit change is exists in Usage.

I've tried to use Webp function with Picture tag based on your usage document, but It won't work due to src attributes. It have worked if I change the tag from ":src" to ":srcset".

Ver of nuxt is as follows.
    "nuxt": "^2.6.2",

Please ignore this P.R if this issue is comes from my misunderstanding or mistake.

Thanks in advance.
