### PR TITLE
corrected name typo in license file

### DIFF
--- a/docs/license.md
+++ b/docs/license.md
@@ -11,7 +11,7 @@ category: "Getting started"
 ```
 MIT License
 
-Copyright (c) 2020 Julo Marquez
+Copyright (c) 2020 Julio Marquez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In the [other license file](https://github.com/juliomrqz/nuxt-optimized-images/blob/develop/LICENSE) it's correct already.